### PR TITLE
fix(ai): recoverable + concurrency-safe model download state machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,8 @@ The project did not previously include a changelog; the entries below summarize 
 - React template `@mlc-ai/web-llm` dependency updated from `^0.2.79` to `^0.2.80` (`880ec30`).
 - Angular template assets configuration updated to avoid missing default asset path issues in generated projects (`880ec30`).
 - CLI TypeScript config now excludes test files from compilation (`1731787`).
+
+### Fixed
+- `ai.models.download()` now enforces single-flight semantics: a duplicate call for the same model returns the in-flight promise, and a call for a different model rejects with `AIErrorCode.DOWNLOAD_IN_PROGRESS` instead of racing shared state ([#14](https://github.com/GhostScientist/nearstack/issues/14)).
+- React, Vue, SvelteKit, and Angular templates now offer a Retry action when a model download fails, so users can recover without reloading the app ([#13](https://github.com/GhostScientist/nearstack/issues/13)).
+- Template model-selection handlers now treat the `error` state like `available` and re-download instead of falling through to `models.use()` and rejecting ([#12](https://github.com/GhostScientist/nearstack/issues/12)).

--- a/packages/ai/src/__tests__/ai.test.ts
+++ b/packages/ai/src/__tests__/ai.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AI, createAI } from '../ai';
 import { AIError, AIErrorCode } from '../errors';
-import type { Provider, Message, ChatOptions, StreamChunk, ModelInfo } from '../types';
+import type {
+  Provider,
+  BrowserProviderInterface,
+  Message,
+  ChatOptions,
+  StreamChunk,
+  ModelInfo,
+} from '../types';
 
 // Create a mock provider
 function createMockProvider(
@@ -25,15 +32,70 @@ function createMockProvider(
   };
 }
 
-function createMockModel(id: string, provider: string): ModelInfo {
+function createMockModel(
+  id: string,
+  provider: string,
+  status: ModelInfo['status'] = { state: 'ready' }
+): ModelInfo {
   return {
     id,
     name: id,
     provider,
     size: 1000000,
     contextLength: 4096,
-    status: { state: 'ready' },
+    status,
   };
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/**
+ * Create a browser-style provider whose downloadModel resolution is
+ * controllable per-call. Tests can drive concurrency by leaving a deferred
+ * unresolved while issuing additional download() calls.
+ */
+function createMockBrowserProvider(
+  id: string,
+  models: ModelInfo[]
+): {
+  provider: BrowserProviderInterface;
+  pendingDownloads: Array<Deferred<void>>;
+} {
+  const pendingDownloads: Array<Deferred<void>> = [];
+  const provider: BrowserProviderInterface = {
+    id,
+    type: 'browser',
+    initialize: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    isAvailable: vi.fn().mockResolvedValue(true),
+    listModels: vi.fn().mockResolvedValue(models),
+    chat: vi.fn().mockResolvedValue('Mock response'),
+    stream: vi.fn().mockImplementation(async function* () {
+      yield { content: 'Mock', done: true, model: 'test', provider: id };
+    }),
+    downloadModel: vi.fn().mockImplementation(async () => {
+      const deferred = createDeferred<void>();
+      pendingDownloads.push(deferred);
+      return deferred.promise;
+    }),
+    deleteModel: vi.fn().mockResolvedValue(undefined),
+    cancelDownload: vi.fn(),
+  };
+  return { provider, pendingDownloads };
 }
 
 describe('AI', () => {
@@ -290,6 +352,71 @@ describe('AI', () => {
         await expect(ai.models.use('unknown')).rejects.toMatchObject({
           code: AIErrorCode.MODEL_NOT_FOUND,
         });
+      });
+    });
+
+    describe('download', () => {
+      it('returns the same promise for concurrent calls with the same modelId', async () => {
+        const { provider, pendingDownloads } = createMockBrowserProvider('browser', [
+          createMockModel('model-a', 'browser', { state: 'available' }),
+        ]);
+        const ai = new AI({ providers: [provider], autoInitialize: true });
+        await ai.ready();
+
+        const first = ai.models.download('model-a');
+        const second = ai.models.download('model-a');
+
+        expect(provider.downloadModel).toHaveBeenCalledTimes(1);
+        // Both callers should observe the same outcome; resolve the single
+        // in-flight download to settle them.
+        pendingDownloads[0].resolve();
+        await expect(Promise.all([first, second])).resolves.toBeDefined();
+        expect(ai.models.get('model-a')?.status.state).toBe('cached');
+      });
+
+      it('rejects a different modelId while one is in flight', async () => {
+        const { provider, pendingDownloads } = createMockBrowserProvider('browser', [
+          createMockModel('model-a', 'browser', { state: 'available' }),
+          createMockModel('model-b', 'browser', { state: 'available' }),
+        ]);
+        const ai = new AI({ providers: [provider], autoInitialize: true });
+        await ai.ready();
+
+        const first = ai.models.download('model-a');
+
+        await expect(ai.models.download('model-b')).rejects.toMatchObject({
+          code: AIErrorCode.DOWNLOAD_IN_PROGRESS,
+        });
+        // The second download must not have invoked the provider.
+        expect(provider.downloadModel).toHaveBeenCalledTimes(1);
+        expect(provider.downloadModel).toHaveBeenCalledWith(
+          'model-a',
+          expect.any(Function)
+        );
+
+        pendingDownloads[0].resolve();
+        await first;
+      });
+
+      it('allows a fresh download after a previous download fails', async () => {
+        const { provider, pendingDownloads } = createMockBrowserProvider('browser', [
+          createMockModel('model-a', 'browser', { state: 'available' }),
+        ]);
+        const ai = new AI({ providers: [provider], autoInitialize: true });
+        await ai.ready();
+
+        const first = ai.models.download('model-a');
+        pendingDownloads[0].reject(new Error('network down'));
+        await expect(first).rejects.toThrow('network down');
+        expect(ai.models.get('model-a')?.status.state).toBe('error');
+
+        // User retries — the second call must reach the provider, not be
+        // blocked by stale in-flight state.
+        const second = ai.models.download('model-a');
+        expect(provider.downloadModel).toHaveBeenCalledTimes(2);
+        pendingDownloads[1].resolve();
+        await second;
+        expect(ai.models.get('model-a')?.status.state).toBe('cached');
       });
     });
 

--- a/packages/ai/src/ai.ts
+++ b/packages/ai/src/ai.ts
@@ -44,6 +44,7 @@ export class AI {
   private providerInstances: Map<string, Provider> = new Map();
   private initPromise: Promise<void> | null = null;
   private downloadAbortController: AbortController | null = null;
+  private inFlightDownload: { modelId: string; promise: Promise<void> } | null = null;
   private debug: boolean;
   private _ui: UIHelpers;
 
@@ -67,51 +68,36 @@ export class AI {
 
     /**
      * Download a model for browser inference.
+     *
+     * Concurrency rules:
+     * - Calling with the same modelId already in flight returns the existing
+     *   promise (idempotent — useful for double-clicks).
+     * - Calling with a different modelId while one is in flight rejects with
+     *   AIErrorCode.DOWNLOAD_IN_PROGRESS. Cancel the active download first
+     *   via models.cancelDownload() if you want to switch.
      */
-    download: async (modelId: string): Promise<void> => {
-      const model = this.models.get(modelId);
-      if (!model) {
-        throw new AIError(
-          AIErrorCode.MODEL_NOT_FOUND,
-          `Model ${modelId} not found`
-        );
-      }
-
-      const provider = this.providerInstances.get(model.provider);
-      if (!provider || !isBrowserProvider(provider)) {
-        throw new AIError(
-          AIErrorCode.PROVIDER_NOT_AVAILABLE,
-          `Provider ${model.provider} does not support model downloads`
-        );
-      }
-
-      this.downloadAbortController = new AbortController();
-
-      try {
-        await provider.downloadModel(modelId, (progress) => {
-          this.stateManager.setDownloading(modelId, progress);
-          this.stateManager.updateModelStatus(modelId, {
-            state: 'downloading',
-            progress,
-          });
-        });
-
-        this.stateManager.setDownloading(null);
-        this.stateManager.updateModelStatus(modelId, { state: 'cached' });
-      } catch (error) {
-        this.stateManager.setDownloading(null);
-        if (error instanceof AIError && error.code === AIErrorCode.DOWNLOAD_CANCELLED) {
-          this.stateManager.updateModelStatus(modelId, { state: 'available' });
-        } else {
-          this.stateManager.updateModelStatus(modelId, {
-            state: 'error',
-            message: error instanceof Error ? error.message : 'Download failed',
-          });
+    download: (modelId: string): Promise<void> => {
+      if (this.inFlightDownload) {
+        if (this.inFlightDownload.modelId === modelId) {
+          return this.inFlightDownload.promise;
         }
-        throw error;
-      } finally {
-        this.downloadAbortController = null;
+        return Promise.reject(
+          new AIError(
+            AIErrorCode.DOWNLOAD_IN_PROGRESS,
+            `Cannot download ${modelId}: ${this.inFlightDownload.modelId} is already downloading`
+          )
+        );
       }
+
+      const promise = this.runDownload(modelId);
+      this.inFlightDownload = { modelId, promise };
+      const clear = () => {
+        if (this.inFlightDownload?.modelId === modelId) {
+          this.inFlightDownload = null;
+        }
+      };
+      promise.then(clear, clear);
+      return promise;
     },
 
     /**
@@ -128,6 +114,9 @@ export class AI {
 
       this.downloadAbortController?.abort();
       this.stateManager.setDownloading(null);
+      // Clear synchronously so a follow-up download() doesn't race the
+      // rejection microtask.
+      this.inFlightDownload = null;
     },
 
     /**
@@ -543,6 +532,56 @@ export class AI {
     }
 
     return { provider, model: modelId };
+  }
+
+  /**
+   * Execute a model download. Wrapped by models.download which enforces
+   * single-flight semantics.
+   */
+  private async runDownload(modelId: string): Promise<void> {
+    const model = this.models.get(modelId);
+    if (!model) {
+      throw new AIError(
+        AIErrorCode.MODEL_NOT_FOUND,
+        `Model ${modelId} not found`
+      );
+    }
+
+    const provider = this.providerInstances.get(model.provider);
+    if (!provider || !isBrowserProvider(provider)) {
+      throw new AIError(
+        AIErrorCode.PROVIDER_NOT_AVAILABLE,
+        `Provider ${model.provider} does not support model downloads`
+      );
+    }
+
+    this.downloadAbortController = new AbortController();
+
+    try {
+      await provider.downloadModel(modelId, (progress) => {
+        this.stateManager.setDownloading(modelId, progress);
+        this.stateManager.updateModelStatus(modelId, {
+          state: 'downloading',
+          progress,
+        });
+      });
+
+      this.stateManager.setDownloading(null);
+      this.stateManager.updateModelStatus(modelId, { state: 'cached' });
+    } catch (error) {
+      this.stateManager.setDownloading(null);
+      if (error instanceof AIError && error.code === AIErrorCode.DOWNLOAD_CANCELLED) {
+        this.stateManager.updateModelStatus(modelId, { state: 'available' });
+      } else {
+        this.stateManager.updateModelStatus(modelId, {
+          state: 'error',
+          message: error instanceof Error ? error.message : 'Download failed',
+        });
+      }
+      throw error;
+    } finally {
+      this.downloadAbortController = null;
+    }
   }
 
   /**

--- a/packages/ai/src/errors.ts
+++ b/packages/ai/src/errors.ts
@@ -16,6 +16,8 @@ export enum AIErrorCode {
   DOWNLOAD_FAILED = 'DOWNLOAD_FAILED',
   /** Download was cancelled by user */
   DOWNLOAD_CANCELLED = 'DOWNLOAD_CANCELLED',
+  /** A different model is already being downloaded */
+  DOWNLOAD_IN_PROGRESS = 'DOWNLOAD_IN_PROGRESS',
   /** Inference request failed */
   INFERENCE_FAILED = 'INFERENCE_FAILED',
   /** Request timed out */
@@ -47,6 +49,8 @@ const ERROR_MESSAGES: Record<AIErrorCode, string> = {
   [AIErrorCode.DOWNLOAD_FAILED]:
     'Model download failed. Check your network connection and try again.',
   [AIErrorCode.DOWNLOAD_CANCELLED]: 'Model download was cancelled.',
+  [AIErrorCode.DOWNLOAD_IN_PROGRESS]:
+    'A different model is already downloading. Wait for it to finish or cancel it before starting another download.',
   [AIErrorCode.INFERENCE_FAILED]:
     'Inference request failed. The model may have encountered an error.',
   [AIErrorCode.TIMEOUT]:

--- a/packages/cli/templates/angular/src/app/app.component.html
+++ b/packages/cli/templates/angular/src/app/app.component.html
@@ -158,6 +158,16 @@
           </div>
           <p class="mt-1 text-xs text-neutral-500">Downloading {{ (downloadProgress * 100) | number: '1.0-0' }}%</p>
         </div>
+        <div *ngIf="selectedModelError" class="mt-3 w-full">
+          <p class="text-xs text-red-600">{{ selectedModelError }}</p>
+          <button
+            (click)="onModelSelect(selectedModel)"
+            [disabled]="isDownloading"
+            class="mt-2 w-full bg-black px-3 py-2 text-sm text-white hover:bg-neutral-800 disabled:opacity-50"
+          >
+            Retry download
+          </button>
+        </div>
       </div>
 
       <!-- Chat -->

--- a/packages/cli/templates/angular/src/app/app.component.ts
+++ b/packages/cli/templates/angular/src/app/app.component.ts
@@ -80,6 +80,11 @@ export class AppComponent implements OnInit {
     return this.models.find(m => m.id === this.selectedModel);
   }
 
+  get selectedModelError(): string | null {
+    const status = this.selectedModelInfo?.status;
+    return status?.state === 'error' ? status.message : null;
+  }
+
   async ngOnInit() {
     await this.refreshNotes();
     NoteModel.subscribe(() => void this.refreshNotes());
@@ -219,11 +224,17 @@ export class AppComponent implements OnInit {
   }
 
   async onModelSelect(modelId: string) {
+    if (this.isDownloading) return;
     this.selectedModel = modelId;
     const model = this.models.find(m => m.id === modelId);
     if (!model) return;
 
-    if (model.status.state === 'available') {
+    // 'error' state needs a fresh download too — otherwise a failed download
+    // leaves the model unusable until reload.
+    const needsDownload =
+      model.status.state === 'available' || model.status.state === 'error';
+
+    if (needsDownload) {
       this.isDownloading = true;
       this.downloadProgress = 0;
       const unsub = this.ai.subscribe(state => {
@@ -236,9 +247,16 @@ export class AppComponent implements OnInit {
       } finally {
         unsub();
         this.isDownloading = false;
+        this.models = this.ai.models.list();
       }
     }
-    await this.ai.models.use(modelId);
+
+    // Only activate if the model is now ready/cached. After a failed download
+    // we'd otherwise reach use() with status 'error' and throw.
+    const refreshed = this.ai.models.get(modelId);
+    if (refreshed?.status.state === 'cached' || refreshed?.status.state === 'ready') {
+      await this.ai.models.use(modelId);
+    }
     this.models = this.ai.models.list();
   }
 

--- a/packages/cli/templates/react/src/components/AIPanel.tsx
+++ b/packages/cli/templates/react/src/components/AIPanel.tsx
@@ -284,7 +284,16 @@ export function AIPanel({ notes, onCreateNote, onUpdateNote, onDeleteNote }: AIP
           )}
 
           {selectedModel?.status?.state === 'error' && (
-            <p className="mt-2 text-xs text-red-600">{selectedModel.status.message}</p>
+            <div className="mt-3 w-full">
+              <p className="text-xs text-red-600">{selectedModel.status.message}</p>
+              <button
+                onClick={() => void downloadModel(selectedModel.id)}
+                disabled={isDownloading}
+                className="mt-2 w-full bg-black px-3 py-2 text-sm text-white hover:bg-neutral-800 disabled:opacity-50"
+              >
+                Retry download
+              </button>
+            </div>
           )}
         </div>
       ) : (

--- a/packages/cli/templates/sveltekit/src/lib/components/AIPanel.svelte
+++ b/packages/cli/templates/sveltekit/src/lib/components/AIPanel.svelte
@@ -16,6 +16,7 @@
   let downloadProgress = 0;
 
   $: selectedModelInfo = models.find(m => m.id === selectedModel);
+  $: selectedModelError = selectedModelInfo?.status.state === 'error' ? selectedModelInfo.status.message : null;
   $: needsSetup = !selectedModelInfo || (selectedModelInfo.status.state !== 'cached' && selectedModelInfo.status.state !== 'ready');
 
   function buildSystemPrompt(): string | undefined {
@@ -37,11 +38,17 @@
   }
 
   async function selectAndDownload() {
+    if (isDownloading) return;
     if (!selectedModel) return;
     const model = models.find(m => m.id === selectedModel);
     if (!model) return;
 
-    if (model.status.state === 'available') {
+    // 'error' state needs a fresh download too — otherwise a failed download
+    // leaves the model unusable until reload.
+    const needsDownload =
+      model.status.state === 'available' || model.status.state === 'error';
+
+    if (needsDownload) {
       isDownloading = true;
       downloadProgress = 0;
       const unsub = ai.subscribe(state => {
@@ -54,9 +61,16 @@
       } finally {
         unsub();
         isDownloading = false;
+        models = ai.models.list();
       }
     }
-    await ai.models.use(selectedModel);
+
+    // Only activate if the model is now ready/cached. After a failed download
+    // we'd otherwise reach use() with status 'error' and throw.
+    const refreshed = ai.models.get(selectedModel);
+    if (refreshed?.status.state === 'cached' || refreshed?.status.state === 'ready') {
+      await ai.models.use(selectedModel);
+    }
     models = ai.models.list();
   }
 
@@ -121,6 +135,18 @@
             <div class="h-full bg-black transition-all" style="width: {Math.round(downloadProgress * 100)}%"></div>
           </div>
           <p class="mt-1 text-xs text-neutral-500">Downloading {Math.round(downloadProgress * 100)}%</p>
+        </div>
+      {/if}
+      {#if selectedModelError}
+        <div class="mt-3 w-full">
+          <p class="text-xs text-red-600">{selectedModelError}</p>
+          <button
+            on:click={selectAndDownload}
+            disabled={isDownloading}
+            class="mt-2 w-full bg-black px-3 py-2 text-sm text-white hover:bg-neutral-800 disabled:opacity-50"
+          >
+            Retry download
+          </button>
         </div>
       {/if}
     </div>

--- a/packages/cli/templates/vue/src/components/AIPanel.vue
+++ b/packages/cli/templates/vue/src/components/AIPanel.vue
@@ -16,6 +16,10 @@ const isDownloading = ref(false);
 const downloadProgress = ref(0);
 
 const selectedModelInfo = computed(() => models.value.find(m => m.id === selectedModel.value));
+const selectedModelError = computed(() => {
+  const status = selectedModelInfo.value?.status;
+  return status?.state === 'error' ? status.message : null;
+});
 const needsSetup = computed(() => {
   const m = selectedModelInfo.value;
   return !m || (m.status.state !== 'cached' && m.status.state !== 'ready');
@@ -40,11 +44,17 @@ function buildSystemPrompt(): string | undefined {
 }
 
 async function selectModelAndDownload() {
+  if (isDownloading.value) return;
   if (!selectedModel.value) return;
   const model = models.value.find(m => m.id === selectedModel.value);
   if (!model) return;
 
-  if (model.status.state === 'available') {
+  // 'error' state needs a fresh download too — otherwise a failed download
+  // leaves the model unusable until reload.
+  const needsDownload =
+    model.status.state === 'available' || model.status.state === 'error';
+
+  if (needsDownload) {
     isDownloading.value = true;
     downloadProgress.value = 0;
     const unsub = props.ai.subscribe(state => {
@@ -57,9 +67,16 @@ async function selectModelAndDownload() {
     } finally {
       unsub();
       isDownloading.value = false;
+      models.value = props.ai.models.list();
     }
   }
-  await props.ai.models.use(selectedModel.value);
+
+  // Only activate if the model is now ready/cached. After a failed download
+  // we'd otherwise reach use() with status 'error' and throw.
+  const refreshed = props.ai.models.get(selectedModel.value);
+  if (refreshed?.status.state === 'cached' || refreshed?.status.state === 'ready') {
+    await props.ai.models.use(selectedModel.value);
+  }
   models.value = props.ai.models.list();
 }
 
@@ -119,6 +136,16 @@ function clear() {
           <div class="h-full bg-black transition-all" :style="{ width: `${Math.round(downloadProgress * 100)}%` }" />
         </div>
         <p class="mt-1 text-xs text-neutral-500">Downloading {{ Math.round(downloadProgress * 100) }}%</p>
+      </div>
+      <div v-if="selectedModelError" class="mt-3 w-full">
+        <p class="text-xs text-red-600">{{ selectedModelError }}</p>
+        <button
+          @click="selectModelAndDownload"
+          :disabled="isDownloading"
+          class="mt-2 w-full bg-black px-3 py-2 text-sm text-white hover:bg-neutral-800 disabled:opacity-50"
+        >
+          Retry download
+        </button>
       </div>
     </div>
 

--- a/packages/react/src/ai/__tests__/useModelSelector.test.ts
+++ b/packages/react/src/ai/__tests__/useModelSelector.test.ts
@@ -1,0 +1,124 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { AIState, ModelInfo } from '@nearstack-dev/ai';
+import { useModelSelector } from '../useModelSelector';
+
+const baseState: AIState = {
+  initialized: true,
+  providers: [],
+  models: [],
+  activeModel: null,
+  activeProvider: null,
+  downloading: null,
+  error: null,
+};
+
+function makeModel(id: string, status: ModelInfo['status']): ModelInfo {
+  return {
+    id,
+    name: id,
+    provider: 'browser',
+    size: 1_000_000,
+    contextLength: 4096,
+    status,
+  };
+}
+
+interface MockAI {
+  state: AIState;
+  download: ReturnType<typeof vi.fn>;
+  use: ReturnType<typeof vi.fn>;
+  ai: any;
+}
+
+function makeMockAI(models: ModelInfo[]): MockAI {
+  const state: AIState = { ...baseState, models };
+  const download = vi.fn().mockResolvedValue(undefined);
+  const use = vi.fn().mockResolvedValue(undefined);
+  const ai = {
+    getState: () => state,
+    subscribe: () => () => undefined,
+    ready: vi.fn().mockResolvedValue(undefined),
+    models: {
+      get: (id: string) => state.models.find(m => m.id === id),
+      download,
+      use,
+    },
+    ui: {
+      getModelChoices: () => [],
+    },
+  };
+  return { state, download, use, ai };
+}
+
+describe('useModelSelector', () => {
+  it('selectModel on a model in error state stages it for retry without calling use()', async () => {
+    const { ai, download, use } = makeMockAI([
+      makeModel('model-a', { state: 'error', message: 'previous failure' }),
+    ]);
+
+    const { result } = renderHook(() => useModelSelector(ai));
+
+    await act(async () => {
+      await result.current.selectModel('model-a');
+    });
+
+    // Errored models should never auto-activate — that path throws.
+    expect(use).not.toHaveBeenCalled();
+    // Hook must not silently kick off a download either; explicit user
+    // action via downloadModel drives the retry.
+    expect(download).not.toHaveBeenCalled();
+    // The selection is staged so the template can render the retry UI.
+    expect(result.current.currentSelection).toBe('model-a');
+    expect(result.current.selectedModel?.status.state).toBe('error');
+  });
+
+  it('downloadModel retries successfully after a previous failure', async () => {
+    const { ai, download, use } = makeMockAI([
+      makeModel('model-a', { state: 'error', message: 'previous failure' }),
+    ]);
+
+    const { result } = renderHook(() => useModelSelector(ai));
+
+    await act(async () => {
+      await result.current.downloadModel('model-a');
+    });
+
+    expect(download).toHaveBeenCalledWith('model-a');
+    expect(use).toHaveBeenCalledWith('model-a');
+  });
+
+  it('downloadModel is a no-op while a download is already in flight', async () => {
+    const { ai, download } = makeMockAI([
+      makeModel('model-a', { state: 'available' }),
+    ]);
+
+    let resolveDownload: () => void;
+    download.mockImplementation(
+      () => new Promise<void>(res => { resolveDownload = res; })
+    );
+
+    const { result } = renderHook(() => useModelSelector(ai));
+
+    let firstCall!: Promise<void>;
+    act(() => {
+      firstCall = result.current.downloadModel('model-a');
+    });
+
+    await waitFor(() => expect(result.current.isDownloading).toBe(true));
+
+    // Second call while the first is still pending should not invoke
+    // download again.
+    await act(async () => {
+      await result.current.downloadModel('model-a');
+    });
+
+    expect(download).toHaveBeenCalledTimes(1);
+
+    // Let the first call finish so the hook returns to idle.
+    await act(async () => {
+      resolveDownload!();
+      await firstCall;
+    });
+  });
+});

--- a/packages/react/src/ai/useModelSelector.ts
+++ b/packages/react/src/ai/useModelSelector.ts
@@ -37,12 +37,15 @@ export function useModelSelector(instance: AI = defaultAI) {
       await instance.models.use(modelId);
       setSelectedModelId(null);
     } else {
-      // For available browser models, just track the selection without calling use()
+      // For available or errored browser models, just track the selection.
+      // The user triggers downloadModel() explicitly. Tracking selections
+      // for errored models is what enables the retry-from-error path.
       setSelectedModelId(modelId);
     }
   };
 
   const downloadModel = async (modelId: string) => {
+    if (isDownloading) return;
     setIsDownloading(true);
     try {
       await instance.models.download(modelId);


### PR DESCRIPTION
## Summary
- Closes #12, #13, #14.
- `ai.models.download()` is now single-flight in the core: same modelId returns the in-flight promise (idempotent for double-clicks); a different modelId rejects with a new `AIErrorCode.DOWNLOAD_IN_PROGRESS` instead of racing shared state. `cancelDownload` clears the in-flight tracker synchronously to avoid microtask races.
- All four templates (React, Vue, SvelteKit, Angular) treat the `error` state like `available` and re-download, instead of falling through to `models.use()` (which rejects). Each template adds a **Retry download** button on error state so users can recover without reloading. Handlers also early-return when a download is already in flight.
- Tests added at the layer where the bugs live: 3 core tests (idempotency, concurrent rejection, error→retry→cached) and 3 React hook tests (error-state staging, retry after failure, concurrent no-op). Full suite stays green: 122 tests across `ai`/`react`/`core`/`cli`.

## Why this layer
The three bugs share one root cause — the model-setup state machine was open-coded in template code, and each framework copy got it slightly wrong. Owning concurrency and the `error → retry` transition in `@nearstack-dev/ai` means the rule is enforced once and tested once; templates only render the new states.

## Test plan
- [x] `pnpm test` from the repo root — all packages green.
- [ ] Manually scaffold each template (`npx @nearstack-dev/cli create ...`), simulate a failed model download, confirm the **Retry download** button appears and recovers cleanly.
- [ ] Manually trigger overlapping downloads (rapid dropdown changes) — confirm the second selection rejects with `DOWNLOAD_IN_PROGRESS` rather than corrupting progress state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)